### PR TITLE
feat: add select function

### DIFF
--- a/lib/i18n.dart
+++ b/lib/i18n.dart
@@ -105,7 +105,7 @@ String select(
   Map<String, String> cases, {
   String? other,
 }) {
-  return _firstNotNull(cases[key], other);
+  return _firstNotNull(cases[key], other ?? key);
 }
 
 Map<String, CategoryResolver> _resolverRegistry = {

--- a/lib/i18n.dart
+++ b/lib/i18n.dart
@@ -97,6 +97,17 @@ String ordinal(
   );
 }
 
+///
+/// Selects one of the cases based on the key.
+///
+String select(
+  String key,
+  Map<String, String> cases, {
+  String? other,
+}) {
+  return _firstNotNull(cases[key], other);
+}
+
 Map<String, CategoryResolver> _resolverRegistry = {
   'en': en.quantityResolver,
   'cs': cs.quantityResolver,

--- a/lib/src/i18n_impl.dart
+++ b/lib/src/i18n_impl.dart
@@ -46,6 +46,12 @@ String generateDartContentFromYaml(Metadata meta, String yamlContent) {
   output.writeln(
     '\ti18n.cardinal(count, _languageCode, zero: zero, one: one, two: two, few: few, many: many, other: other,);',
   );
+  output.writeln(
+    'String _select(String key, Map<String, String> cases, {String? other,}) =>',
+  );
+  output.writeln(
+    '\ti18n.select(key, cases, other: other);',
+  );
   output.writeln('');
 
   for (final translation in translations) {

--- a/lib/src/i18n_impl.dart
+++ b/lib/src/i18n_impl.dart
@@ -19,7 +19,7 @@ String generateDartContentFromYaml(Metadata meta, String yamlContent) {
 
   output.writeln('// GENERATED FILE, do not edit!');
   output.writeln(
-    '// ignore_for_file: annotate_overrides, non_constant_identifier_names, prefer_single_quotes, unused_element, unused_field',
+    '// ignore_for_file: annotate_overrides, non_constant_identifier_names, prefer_single_quotes, unused_element, unused_field, unnecessary_string_interpolations',
   );
   output.writeln('import \'package:i18n/i18n.dart\' as i18n;');
   if (meta.defaultFileName != null) {

--- a/test/i18n_test.dart
+++ b/test/i18n_test.dart
@@ -107,7 +107,7 @@ void main() {
       );
       expect(
         select('bar', {'foo': 'FOO!'}),
-        equals('???'),
+        equals('bar'),
       );
     });
   });

--- a/test/i18n_test.dart
+++ b/test/i18n_test.dart
@@ -89,6 +89,29 @@ void main() {
     });
   });
 
+  group('Select', () {
+    test('With other', () {
+      expect(
+        select('foo', {'foo': 'FOO!'}, other: 'OTHER!'),
+        equals('FOO!'),
+      );
+      expect(
+        select('bar', {'foo': 'FOO!'}, other: 'OTHER!'),
+        equals('OTHER!'),
+      );
+    });
+    test('Without other', () {
+      expect(
+        select('foo', {'foo': 'FOO!'}),
+        equals('FOO!'),
+      );
+      expect(
+        select('bar', {'foo': 'FOO!'}),
+        equals('???'),
+      );
+    });
+  });
+
   group('Message building', () {
     test('Todo list', () {
       final root = Metadata(
@@ -150,3 +173,4 @@ void testMeta(
     expect(meta.languageCode, equals(languageCode));
   });
 }
+


### PR DESCRIPTION
## Summary

This PR implements a simple `select` function for use in translation values.

This makes it easier to select from static values based on mappings.

**Before:**

```yaml
providers:
  name(String provider): |-
    ${{
      'facebook': 'Facebook',
      'google': 'Google',
      'apple': 'Apple',
    }[provider] ?? 'Other'}
```

**After:**

```yaml
providers:
  name(String provider): |-
    ${_select(provider, {
      'facebook': 'Facebook',
      'google': 'Google',
      'apple': 'Apple',
    }, other: 'Other')}
```

## Alternative solutions

If there is any reason not to include this, maybe consider adding the ability to code-split the generated file somehow, or allow some custom code injection in the output?

I am not sure there is a configuration flow to use here, but if there is, maybe allowing to inject `part 'my_custom_files.dart';` or inject entire methods inside would make this PR useless.

It would also open up many new options for customizing behavior.

