### PR TITLE
feat: add doc comments to keys

### DIFF
--- a/lib/src/i18n_impl.dart
+++ b/lib/src/i18n_impl.dart
@@ -1,5 +1,7 @@
 library i18n;
 
+import 'dart:convert';
+
 import 'package:yaml/yaml.dart';
 
 import 'metadata.dart';
@@ -158,11 +160,12 @@ void renderTranslation(Translation translation, StringBuffer output) {
       output.writeln('\t$className get $keyName => $className(this);');
     } else {
       final comment = _wrapWithComments(v);
+      output.writeln(comment);
       if (k.contains('(')) {
         // function
-        output.writeln('\t$comment\n\tString $keyName => """$v""";');
+        output.writeln('\tString $keyName => """$v""";');
       } else {
-        output.writeln('\t$comment\n\tString get $keyName => """$v""";');
+        output.writeln('\tString get $keyName => """$v""";');
       }
     }
   });
@@ -174,20 +177,20 @@ String _wrapWithComments(dynamic obj) {
   if (text == null || text.isEmpty) {
     return '';
   }
-  final lines = text.split('\n');
+  final lines = LineSplitter().convert(text);
   final output = StringBuffer();
   final isMultiline = lines.length > 1;
+  output.writeln('/// ```dart');
   if (isMultiline) {
-    lines.insert(0, '"""');
-    lines.add('"""');
-    output.writeln('/// ```dart');
+    output.writeln('/// """');
     for (final line in lines) {
       output.writeln('/// $line');
     }
-    output.writeln('/// ```');
+    output.writeln('/// """');
   } else {
-    output.writeln('/// `$text`');
+    output.writeln('/// "$text"');
   }
+  output.writeln('/// ```');
   return output.toString().trimRight();
 }
 

--- a/lib/src/i18n_impl.dart
+++ b/lib/src/i18n_impl.dart
@@ -157,15 +157,38 @@ void renderTranslation(Translation translation, StringBuffer output) {
       final className = meta.nest(prefix).objectName.convertName();
       output.writeln('\t$className get $keyName => $className(this);');
     } else {
+      final comment = _wrapWithComments(v);
       if (k.contains('(')) {
         // function
-        output.writeln('\tString $keyName => """$v""";');
+        output.writeln('\t$comment\n\tString $keyName => """$v""";');
       } else {
-        output.writeln('\tString get $keyName => """$v""";');
+        output.writeln('\t$comment\n\tString get $keyName => """$v""";');
       }
     }
   });
   output.writeln('}');
+}
+
+String _wrapWithComments(dynamic obj) {
+  final text = obj?.toString();
+  if (text == null || text.isEmpty) {
+    return '';
+  }
+  final lines = text.split('\n');
+  final output = StringBuffer();
+  final isMultiline = lines.length > 1;
+  if (isMultiline) {
+    lines.insert(0, '"""');
+    lines.add('"""');
+    output.writeln('/// ```dart');
+    for (final line in lines) {
+      output.writeln('/// $line');
+    }
+    output.writeln('/// ```');
+  } else {
+    output.writeln('/// `$text`');
+  }
+  return output.toString().trimRight();
 }
 
 void prepareTranslationList(
@@ -203,3 +226,4 @@ void renderMapEntries(YamlMap messages, StringBuffer output, String prefix) {
 String _renderFileNameError(String name) {
   return 'File name can not contain more than 2 "_" characters: \'$name\'';
 }
+


### PR DESCRIPTION
## Summary

This PR enriches the translation keys with their respective values in doc strings for Dart.

This lets you hover/highlight the key in most IDEs and get the actual value, which can help make sure you are using the correct key, or to see where parameters will be placed, etc.

### Example:

![image](https://github.com/MohiuddinM/i18n/assets/167217/28e4690c-cda4-4d94-bec2-465ed6434736)
