### PR TITLE
Feature: Multi base file support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.1.1
+
+- added multi base file support (by [shovelmn12](https://github.com/MohiuddinM/i18n/pull/30))
+
 ## 4.1.0
 
 - add doc comments for generated keys (by [chenasraf](https://github.com/MohiuddinM/i18n/pull/29))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 4.1.1
 
-- added multi base file support (by [shovelmn12](https://github.com/MohiuddinM/i18n/pull/30))
+- add multi base file support (by [shovelmn12](https://github.com/MohiuddinM/i18n/pull/30))
 
 ## 4.1.0
 

--- a/lib/builder.dart
+++ b/lib/builder.dart
@@ -40,7 +40,7 @@ class YamlBasedBuilder implements Builder {
 
     final allFiles = await buildStep.findAssets(Glob('**.i18n.yaml')).toList();
     final defaultFile = allFiles.firstWhere(
-      (e) => !e.uri.pathSegments.last.contains('_'),
+      (e) => !e.uri.pathSegments.last.contains('_') && currentFile.pathSegments.last.replaceAll(".i18n.yaml", "").startsWith(e.uri.pathSegments.last.replaceAll(".i18n.yaml", "")),
     );
 
     if (currentFile != defaultFile) {

--- a/lib/builder.dart
+++ b/lib/builder.dart
@@ -40,7 +40,11 @@ class YamlBasedBuilder implements Builder {
 
     final allFiles = await buildStep.findAssets(Glob('**.i18n.yaml')).toList();
     final defaultFile = allFiles.firstWhere(
-      (e) => !e.uri.pathSegments.last.contains('_') && currentFile.pathSegments.last.replaceAll(".i18n.yaml", "").startsWith(e.uri.pathSegments.last.replaceAll(".i18n.yaml", "")),
+      (e) {
+        final name = e.uri.pathSegments.last.replaceAll(".i18n.yaml", "");
+
+        return !name.contains('_') && currentFile.pathSegments.last.replaceAll(".i18n.yaml", "").startsWith(name);
+      },
     );
 
     if (currentFile != defaultFile) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: i18n
 description: Simple i18n solution for dart and flutter. Uses code generation to generate translations as dart classes. Efficient and works with autocomplete!
-version: 4.1.0
+version: 4.1.1
 homepage: https://github.com/MohiuddinM/i18n
 
 environment:


### PR DESCRIPTION
With the extra code we can now generate different base files:

```
messages.i18n.yaml
messages_de.i18n.yaml
otherMessages.i18n.yaml
otherMessages_de.i18n.yaml
```

Will now generate:
```
messages.i18n.dart
messages_de.i18n.dart
otherMessages.i18n.dart
otherMessages_de.i18n.dart
```

As I added code to compare base file name, when running the builder will search for "defaultFile" with no "_" and that current file starts with fileName.

https://github.com/shovelmn12/i18n/blob/55a8467a530d99d75911c560ca3d573b864fbbf1/lib/builder.dart#L43